### PR TITLE
Add support for audio in 32-bit float WAV file

### DIFF
--- a/app/canopy-app.html
+++ b/app/canopy-app.html
@@ -338,9 +338,9 @@
       <div class="modal-body">
         <p>Choose format...</p>
         <paper-menu>
-          <paper-item>WAV (RIFF) 16-bit PCM</paper-item>
+          <paper-item disabled>WAV (RIFF) 16-bit PCM</paper-item>
           <paper-item disabled>WAV (RIFF) 24-bit PCM</paper-item>
-          <paper-item disabled>WAV (RIFF) 32-bit PCM (float)</paper-item>
+          <paper-item>WAV (RIFF) 32-bit PCM (float)</paper-item>
         </paper-menu>
       </div>
       <div class="buttons">


### PR DESCRIPTION
_createWaveFileBlobFromAudioBuffer supports saving the buffer in a
32-bit float wav file.

Disabled the 16-bit format in favor of 32-bit float format.